### PR TITLE
check isArray before call

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@
   if (matched[1].indexOf('12') !== 0) return;
   Array.prototype._reverse = Array.prototype.reverse;
   Array.prototype.reverse = function reverse() {
-    this.length = this.length;
+    if (Array.isArray(this)) this.length = this.length;
     return Array.prototype._reverse.call(this);
   }
   var nonenum = {enumerable: false};


### PR DESCRIPTION
only (some) real arrays affected by the bug. So we check it to avoid add length:undefined for non ArrayLike object.